### PR TITLE
map: display node as "offline" only if both ping and respondd replies…

### DIFF
--- a/webroot/js/view/map.js
+++ b/webroot/js/view/map.js
@@ -103,8 +103,14 @@ export class MapView extends View {
 			tx5 = node.wireless.txpower5 || '-';
 
 		startdate.setMinutes(startdate.getMinutes() - config.node.offline);
-		if (new Date(node.lastseen) < startdate) {
-			if (node.pingstate.some((x)=>x)) {
+		const reachableByRespondd = (new Date(node.lastseen) >= startdate);
+		const reachableByPing = (node.pingstate.some((x)=>x));
+		if (reachableByPing) {
+			if (!reachableByRespondd) {
+				className += ' warn';
+			}
+		}else{
+			if (reachableByRespondd) {
 				className += ' warn';
 			}else{
 				className += ' offline';


### PR DESCRIPTION
… are missing

If node is reachable both by ping and respondd, node is now displayed as up.
If one of ping or respondd is down, node is displayed in "warning" state.

Hab diese Änderung nicht getestet...